### PR TITLE
[PR] Add height to cropped spine for authenticated users

### DIFF
--- a/style.css
+++ b/style.css
@@ -254,6 +254,10 @@ body.admin-bar {
 .admin-bar #spine #glue {
 	margin-top: 32px;
 	}
+.admin-bar #spine.cropped {
+	height: 230px;
+	min-height: 230px;
+}
 }
 
 @media (max-width: 989px) {


### PR DESCRIPTION
This corrects an issue where spine icons are floating beneath the
cropped spine when an authenticated user in WordPress is viewing
the page.
