### PR TITLE
[PR] BUG Wrap new spine_is_sub() with spine_is_subpage()

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -123,6 +123,10 @@ add_filter('get_image_tag_class', 'image_tag_class', 0, 4);
 */
 
 // SECTIONING
+// @todo remove this hack... :)
+function spine_is_subpage() {
+	return spine_is_sub();
+}
 
 function spine_is_sub() {
     $post = get_post();


### PR DESCRIPTION
In 01c98f8dc0, spine_is_subpage was renamed to spine_is_sub, breaking
themes that relied on this function with a fatal error.

This commit adds a wrapper function just in case the change was
intended. We can remove either or in the future when themes are
prepped for it.
