### PR TITLE
[PR] Ensure localized Javascript data exists for the builder

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,7 +1,7 @@
 <?php
 
 // Global version tracker.
-$wsuwp_spine_theme_version = '0.1.2';
+$wsuwp_spine_theme_version = '0.1.3';
 
 include_once( 'includes/main-header.php' ); // Include main header functionality.
 include_once( 'includes/customizer/customizer.php' ); // Include customizer functionality.

--- a/inc/builder.php
+++ b/inc/builder.php
@@ -15,6 +15,8 @@ class Spine_Builder_Custom {
 	}
 
 	public function enqueue_scripts() {
+		global $pagenow;
+
 		wp_enqueue_script(
 			'ttfmake-admin-edit-page',
 			get_template_directory_uri() . '/inc/builder-custom/js/edit-page.js',
@@ -30,9 +32,10 @@ class Spine_Builder_Custom {
 
 		wp_localize_script(
 			'ttfmake-admin-edit-page',
-			'TTFMakeEditPage',
+			'ttfmakeEditPageData',
 			array(
-				'featuredImage' => __( 'Featured images are not available for this page while using the current page template.', 'ttfmake' )
+				'featuredImage' => __( 'Featured images are not available for this page while using the current page template.', 'make' ),
+				'pageNow'       => esc_js( $pagenow ),
 			)
 		);
 	}


### PR DESCRIPTION
Without this, false expectation of the builder template occurs
rather than the real thing.
