### PR TITLE
[PR] Add a spine_pre_jacket_html action to output pre #jacket HTML

### DIFF
--- a/header.php
+++ b/header.php
@@ -39,5 +39,7 @@
 	}
 ?>
 
+<?php do_action( 'spine_pre_jacket_html' ); ?>
+
 <div id="jacket" class="style-<?php echo esc_attr( spine_get_option( 'theme_style' ) ); echo $opensans_included; ?>">
 <div id="binder" class="<?php echo esc_attr( spine_get_option( 'grid_style' ) ); echo esc_attr( spine_get_option( 'large_format' ) ); echo esc_attr( spine_get_option( 'broken_binding' ) ); ?>">


### PR DESCRIPTION
The specific use case is for adding a sitewide color bar at the top
of the DOM. This should be used with care, but allows custom elements
to be inserted in the DOM above #jacket without having to overwrite
the full header template—something that can lead to long term
maintenance issues
