### PR TITLE
[PR] Adjustments to Main Header sup and sub

### DIFF
--- a/includes/main-header.php
+++ b/includes/main-header.php
@@ -206,7 +206,7 @@ function spine_get_main_header() {
 
 		if ( 0 === $page_for_posts ) {
 			$page_title = $site_name;
-			$sub_header_default = $site_name;
+			$sub_header_default = $site_tagline;
 		} else {
 			$sub_header_default = $posts_page_title;
 			$page_title = $posts_page_title;


### PR DESCRIPTION
Adds to previous commits from @natejacobson to identify proper behavior for the main header `sup` and `sub` elements.

For `sup`:
1. By default, the WordPress Site Name setting is `sup`
2. If a Global Sup Header is set in customizer, this overrides the site name as `sup`.
3. If a single post or page has `sup` meta, this overrides the global header for that page view.
4. If a child theme uses the `spine_sup_header_default` filter, that overrides.
5. If a child theme uses the `spine_main_header_elements` filter to filter all pieces, that overrides.

`sub` starts off blank, but is guaranteed to be filled in:
1. If archive, use the archive title.
2. If single, use either the post type label or the page for posts title.
3. If a page, use the section title if a sub page, the site's tagline if a top level parent page.
4. If the front page, use the site's tagline.
5. If home, and not the page for posts, use the site's tagline.
6. If home, and the page for posts, use the page for posts title.
7. If search, use "Search Results".
8. If a 404, use "Page Not Found".
9. If a Global Sub Header is set in customizer, this overrides any previous setting for `sub`.
10. If a single post or page has `sub` meta, this overrides the global header for that page view.
11. If a child theme uses the `spine_sub_header_default` filter, that overrides.
12. If a child theme uses the `spine_main_header_elements` filter to filter all pieces, that overrides.
