### PR TITLE
[PR] Update breakpoint for moving WordPress admin bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -239,8 +239,9 @@ body.admin-bar {
 #wpadminbar .ab-top-menu>.menupop>.ab-sub-wrapper {
     bottom:32px;
     box-shadow: none;
-}   
 }
+}
+
 @media (max-width: 780px) {
 
 body.admin-bar {


### PR DESCRIPTION
With the previous breakpoint, the WordPress admin bar would move to the bottom of the screen while the left nav continued to display.
