### PR TITLE
[PR] Update sup-header for tag and university category archives

### DIFF
--- a/includes/main-header.php
+++ b/includes/main-header.php
@@ -149,7 +149,7 @@ function spine_get_main_header() {
 		if ( is_category() ) {
 			$sub_header_default = single_cat_title( '', false );
 		} else if ( is_tag() ) {
-			$sub_header_default = single_tag_title( 'Tag: ', false );
+			$sub_header_default = single_tag_title( '', false );
 		} else if ( is_tax( 'wsuwp_university_category' ) ) {
 			$sub_header_default = single_term_title( '', false );
 		} else if ( is_day() ) {


### PR DESCRIPTION
The header of "Archives" is too generic for things that we know exist.
- Update tag archives to show "Tag: tag name" in the sup header
- Update university category archives to show the university category
