### PR TITLE
[PR] Set a main class in search results, also a default

### DIFF
--- a/index.php
+++ b/index.php
@@ -14,6 +14,10 @@ if ( is_home() ) {
 	$main_class = 'spine-tax-index';
 } elseif ( is_archive() ) {
 	$main_class = 'spine-archive-index';
+} elseif ( is_search() ) {
+	$main_class = 'spine-search-index';
+} else {
+	$main_class = '';
 }
 
 ?>


### PR DESCRIPTION
Avoid a PHP notice by ensuring `$main_class` is always set.
