### PR TITLE
[PR] Correct overlapping media query controlling admin bar on mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -224,7 +224,7 @@ article footer a:hover {
 	}
 
 /* Admin Bar */
-@media (min-width: 989px) {
+@media (min-width: 990px) {
 .admin-bar #spine #glue {
 	margin-top: 32px;
 	}


### PR DESCRIPTION
An overlap with `min-width: 989px` and `max-width: 989px` leads to
undesired behavior and a blank space.

Fixes #138
