### PR TITLE
[PR] Use our banner-slide template, not the default

### DIFF
--- a/inc/builder.php
+++ b/inc/builder.php
@@ -623,8 +623,8 @@ class Spine_Builder_Custom {
 		$templates = array(
 			array(
 				'id' => 'banner-slide',
-				'builder_template' => 'sections/builder-templates/banner-slide',
-				'path' => 'inc/builder/',
+				'builder_template' => 'admin/banner-slide',
+				'path' => 'builder-templates/',
 			),
 		);
 


### PR DESCRIPTION
This resolves an issue where the `slide-url` input was not appearing in production
