### PR TITLE
[PR] Use correct `make_` filters rather than old `ttfmake_`

### DIFF
--- a/inc/builder/core/save.php
+++ b/inc/builder/core/save.php
@@ -334,10 +334,10 @@ class TTFMAKE_Builder_Save {
 	 */
 	public function generate_post_content( $data ) {
 		// Run wpautop when saving the data
-		add_filter( 'ttfmake_the_builder_content', 'wpautop' );
+		add_filter( 'make_the_builder_content', 'wpautop' );
 
 		// Handle oEmbeds correctly
-		add_filter( 'ttfmake_the_builder_content', array( $this, 'embed_handling' ), 8 );
+		add_filter( 'make_the_builder_content', array( $this, 'embed_handling' ), 8 );
 		add_filter( 'embed_handler_html', array( $this, 'embed_handler_html' ) , 10, 3 );
 		add_filter( 'embed_oembed_html', array( $this, 'embed_oembed_html' ) , 10, 4 );
 

--- a/inc/builder/sections/section-definitions.php
+++ b/inc/builder/sections/section-definitions.php
@@ -566,7 +566,7 @@ class TTFMAKE_Section_Definitions {
 		}
 
 		// Add additional dependencies to the Builder JS
-		add_filter( 'ttfmake_builder_js_dependencies', array( $this, 'add_js_dependencies' ) );
+		add_filter( 'make_builder_js_dependencies', array( $this, 'add_js_dependencies' ) );
 
 		// Add the section CSS
 		wp_enqueue_style(


### PR DESCRIPTION
At some point, Make changed all actions and filters to be prefixed with `make_` instead of `ttfmake_`. There is a back compat converter in the upstream theme that I'm guessing I missed in the sync to our build. Rather than trying to maintain backcompat, this adjusts the current `ttfmake_` filters to be `make_` filters and should resolve #145
