### PR TITLE
[PR] Add a later priority to script enqueue to aid a proper cascade

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -205,7 +205,7 @@ function spine_social_options() {
 	return $social;
 }
 
-add_action( 'wp_enqueue_scripts', 'spine_wp_enqueue_scripts' );
+add_action( 'wp_enqueue_scripts', 'spine_wp_enqueue_scripts', 20 );
 /**
  * Enqueue scripts and styles required for front end pageviews.
  */


### PR DESCRIPTION
TablePress default styles are being added after our theme styles and the custom CSS plugin styles. This causes trouble when trying to override the default styling of a table.
