### PR TITLE
[PR] Add `pad-ends` to section in footer of single views

### DIFF
--- a/single.php
+++ b/single.php
@@ -35,7 +35,7 @@ if ( function_exists( 'wsuwp_uc_get_object_type_slugs' ) && in_array( get_post_t
 ?>
 
 <footer class="main-footer">
-	<section class="row halves pager prevnext gutter">
+	<section class="row halves pager prevnext gutter pad-ends">
 		<div class="column one">
 			<?php previous_post_link(); ?>
 		</div>


### PR DESCRIPTION
Without `pad-ends`, no padding is on the section, which results
in a display that does not match the rest of our default section
styling.