### PR TITLE
[PR] Column overlay in single admin template should have a unique ID

### DIFF
--- a/builder-templates/admin/single.php
+++ b/builder-templates/admin/single.php
@@ -7,7 +7,7 @@ $content = ( isset( $ttfmake_section_data['data']['content'] ) ) ? $ttfmake_sect
 
 $iframe_id   = 'ttfmake-iframe-' . $section_id;
 $textarea_id = 'ttfmake-content-' . $section_id;
-$overlay_id  = 'ttfmake-overlay-' . $section_id;
+$overlay_id  = 'ttfmake-overlay-' . $section_id . '-1';
 $title       = ( isset( $ttfmake_section_data['data']['title'] ) ) ? $ttfmake_section_data['data']['title'] : '';
 
 $item_has_content = ( ! empty( $content ) ) ? ' item-has-content' : '';


### PR DESCRIPTION
The ID used when outputting the column overlay data in the single
section template matched the overlay date used for the section
itself. This caused only the entry for Column configuration to
appear whether configuration was selected for column or section.

Adding a -1 to the ID mimics what we do in our columns layout and
fixes the issue.

Fixes #158