### PR TITLE
[PR] Ensure defaults are available for social options in the Spine

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -84,17 +84,12 @@ function spine_get_campus_home_url() {
 }
 
 /**
- * Retrieve the requested spine option from the database.
+ * A set of defaults for the options set in the customizer for the Spine theme.
  *
- * @param string $option_name The option name or key to retrieve.
- *
- * @return mixed The value of the option if found. False if not found.
+ * @return array List of default options.
  */
-function spine_get_option( $option_name ) {
-	$spine_options = get_option( 'spine_options' );
-
-	// Defaults for the spine options will be compared to what is stored in spine_options.
-	$defaults = array(
+function spine_get_option_defaults() {
+	return array(
 		'spine_version'             => '1',
 		'grid_style'                => 'hybrid',
 		'campus_location'           => '',
@@ -124,7 +119,29 @@ function spine_get_option( $option_name ) {
 		'contact_ContactPoint'      => '',
 		'contact_ContactPointTitle' => 'Contact Page...',
 		'archive_content_display'   => 'full',
+		'social_spot_one_type'      => 'facebook',
+		'social_spot_one'           => 'https://www.facebook.com/WSUPullman',
+		'social_spot_two_type'      => 'twitter',
+		'social_spot_two'           => 'https://twitter.com/wsupullman',
+		'social_spot_three_type'    => 'youtube',
+		'social_spot_three'         => 'https://www.youtube.com/washingtonstateuniv',
+		'social_spot_four_type'     => 'directory',
+		'social_spot_four'          => 'http://social.wsu.edu',
 	);
+}
+
+/**
+ * Retrieve the requested spine option from the database.
+ *
+ * @param string $option_name The option name or key to retrieve.
+ *
+ * @return mixed The value of the option if found. False if not found.
+ */
+function spine_get_option( $option_name ) {
+	$spine_options = get_option( 'spine_options' );
+
+	// Defaults for the spine options will be compared to what is stored in spine_options.
+	$defaults = spine_get_option_defaults();
 
 	// A child theme can override all spine option defaults with the spine_option_defaults filter.
 	$defaults = apply_filters( 'spine_option_defaults', $defaults );
@@ -206,6 +223,14 @@ function spine_get_open_sans_condensed_options() {
  */
 function spine_social_options() {
 	$spine_options = get_option( 'spine_options' );
+
+	// Defaults for the spine options will be compared to what is stored in spine_options.
+	$defaults = spine_get_option_defaults();
+
+	// A child theme can override all spine option defaults with the spine_option_defaults filter.
+	$defaults = apply_filters( 'spine_option_defaults', $defaults );
+
+	$spine_options = wp_parse_args( $spine_options, $defaults );
 
 	$social = array();
 

--- a/includes/customizer/customizer.php
+++ b/includes/customizer/customizer.php
@@ -212,7 +212,7 @@ function spine_customize_register( $wp_customize ){
 	));
 
 	// Location Two
-	$wp_customize->add_setting('spine_options[social_spot_two]', array( 'default' => 'http://twitter.com/wsupullman', 'capability' => 'edit_theme_options', 'type' => 'option' ));
+	$wp_customize->add_setting('spine_options[social_spot_two]', array( 'default' => 'https://twitter.com/wsupullman', 'capability' => 'edit_theme_options', 'type' => 'option' ));
 	$wp_customize->add_control('social_spot_two', array( 'section' => 'section_spine_social', 'settings' => 'spine_options[social_spot_two]', 'priority' => 304 ));
 
 	$wp_customize->add_setting('spine_options[social_spot_two_type]', array( 'default' => 'twitter', 'capability' => 'edit_theme_options', 'type' => 'option' ));
@@ -226,7 +226,7 @@ function spine_customize_register( $wp_customize ){
 	));
 
 	// Location Three
-	$wp_customize->add_setting('spine_options[social_spot_three]', array( 'default' => 'http://www.youtube.com/washingtonstateuniv', 'capability' => 'edit_theme_options', 'type' => 'option' ));
+	$wp_customize->add_setting('spine_options[social_spot_three]', array( 'default' => 'https://www.youtube.com/washingtonstateuniv', 'capability' => 'edit_theme_options', 'type' => 'option' ));
 	$wp_customize->add_control('social_spot_three', array( 'section' => 'section_spine_social', 'settings' => 'spine_options[social_spot_three]', 'priority' => 306 ));
 
 	$wp_customize->add_setting('spine_options[social_spot_three_type]', array( 'default' => 'youtube', 'capability' => 'edit_theme_options', 'type' => 'option' ));


### PR DESCRIPTION
* Adds `spine_get_option_defaults()` for reuse of default options. This allows us to grab a set of defaults to use with our `spine_get_option()` function and in `spine_social_options()`. We can likely use it in Customizer as well at some point in the future.
* Provides defaults for the social spot data.
* Change default Twitter and Youtube URLs to use HTTPS