### PR TITLE
Add wrappers for more links when auto truncating

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -460,7 +460,7 @@ function spine_trim_excerpt( $text ) {
 		$excerpt_word_count = 105;
 		$excerpt_length = apply_filters( 'excerpt_length', $excerpt_word_count );
 
-		$excerpt_end = '... <a href="' . get_permalink() . '">' . '&raquo; More ...' . '</a>';
+		$excerpt_end = '... <a href="' . get_permalink() . '" class="truncate-more-link"><span class="truncate-more-default">' . '&raquo; More ...' . '</span></a>';
 		$excerpt_more = apply_filters( 'excerpt_more', ' ' . $excerpt_end );
 
 		$words = preg_split( "/[\n\r\t ]+/", $text, $excerpt_length + 1, PREG_SPLIT_NO_EMPTY );

--- a/functions.php
+++ b/functions.php
@@ -620,33 +620,32 @@ function spine_sectioned_body_classes( $classes ) {
 	return array_unique( $classes );
 }
 
+add_filter( 'post_class', 'spine_excerpt_style_classes' );
 /**
  * Add excerpt style in classes to article on list views.
  *
- * @param array $classes List of classes to be added to the body element.
+ * @param array $classes List of classes to be added to the article element.
  *
  * @return array Modified list of classes.
  */
 function spine_excerpt_style_classes( $classes ) {
 	global $post;
-	if ( ! is_singular() ) {
+	if ( !is_singular() ) {
 			
-			if ( $post->post_excerpt ) {
-				$classes[] = "summary-excerpted";
-			} elseif ( strstr( $post->post_content, '<!--more-->' ) ) {
-				$classes[] = "summary-divided";
-			} elseif ( 'excerpt' === spine_get_option( 'archive_content_display' ) ) {
-				$classes[] = "summary-truncated";
-			} else {
-				$classes[] = "summary-unabridged";
-			}
-			
-			return $classes;
-		
+		if ( $post->post_excerpt ) {
+			$classes[] = "summary-excerpted";
+		} elseif ( strstr( $post->post_content, '<!--more-->' ) ) {
+			$classes[] = "summary-divided";
+		} elseif ( 'excerpt' === spine_get_option( 'archive_content_display' ) ) {
+			$classes[] = "summary-truncated";
+		} else {
+			$classes[] = "summary-unabridged";
 		}
 	}
 	
-add_filter( 'post_class', 'spine_excerpt_style_classes' );
+	return $classes;
+}
+
 
 add_filter( 'safecss_default_css', 'spine_editcss_intro' );
 /**

--- a/functions.php
+++ b/functions.php
@@ -461,6 +461,7 @@ function spine_trim_excerpt( $text ) {
 		$excerpt_length = apply_filters( 'excerpt_length', $excerpt_word_count );
 
 		$excerpt_end = '... <a href="' . get_permalink() . '" class="truncate-more-link"><span class="truncate-more-default">' . '&raquo; More ...' . '</span></a>';
+		$excerpt_end = '... <a href="' . get_permalink() . '" class="more-link"><span class="more-default">' . '&raquo; More ...' . '</span></a>';
 		$excerpt_more = apply_filters( 'excerpt_more', ' ' . $excerpt_end );
 
 		$words = preg_split( "/[\n\r\t ]+/", $text, $excerpt_length + 1, PREG_SPLIT_NO_EMPTY );

--- a/functions.php
+++ b/functions.php
@@ -460,7 +460,6 @@ function spine_trim_excerpt( $text ) {
 		$excerpt_word_count = 105;
 		$excerpt_length = apply_filters( 'excerpt_length', $excerpt_word_count );
 
-		$excerpt_end = '... <a href="' . get_permalink() . '" class="truncate-more-link"><span class="truncate-more-default">' . '&raquo; More ...' . '</span></a>';
 		$excerpt_end = '... <a href="' . get_permalink() . '" class="more-link"><span class="more-default">' . '&raquo; More ...' . '</span></a>';
 		$excerpt_more = apply_filters( 'excerpt_more', ' ' . $excerpt_end );
 
@@ -621,6 +620,33 @@ function spine_sectioned_body_classes( $classes ) {
 	return array_unique( $classes );
 }
 
+/**
+ * Add excerpt style in classes to article on list views.
+ *
+ * @param array $classes List of classes to be added to the body element.
+ *
+ * @return array Modified list of classes.
+ */
+function spine_excerpt_style_classes( $classes ) {
+	global $post;
+	if ( ! is_singular() ) {
+			
+			if ( $post->post_excerpt ) {
+				$classes[] = "summary-excerpted";
+			} elseif ( strstr( $post->post_content, '<!--more-->' ) ) {
+				$classes[] = "summary-divided";
+			} elseif ( 'excerpt' === spine_get_option( 'archive_content_display' ) ) {
+				$classes[] = "summary-truncated";
+			} else {
+				$classes[] = "summary-unabridged";
+			}
+			
+			return $classes;
+		
+		}
+	}
+	
+add_filter( 'post_class', 'spine_excerpt_style_classes' );
 
 add_filter( 'safecss_default_css', 'spine_editcss_intro' );
 /**


### PR DESCRIPTION
These classes and the interior span allow for targeting heterogenous
archive listings and overriding default more text using :before or
:after generated content. We already have these tags in place when using a read-more break.