### PR TITLE
[PR] Add a parts/footers template to all templates closing `main`

### DIFF
--- a/404.php
+++ b/404.php
@@ -24,6 +24,9 @@
 			</div><!--/column-->
 
 		</section>
+
+		<?php get_template_part( 'parts/footers' ); ?>
+
 	</main>
 
 <?php get_footer(); ?>

--- a/index.php
+++ b/index.php
@@ -55,6 +55,9 @@ $args = array(
 			</div>
 		</section><!--pager-->
 	</footer>
+
+	<?php get_template_part( 'parts/footers' ); ?>
+
 </main>
 <?php
 

--- a/page.php
+++ b/page.php
@@ -25,6 +25,8 @@
 
 </section>
 
+	<?php get_template_part( 'parts/footers' ); ?>
+
 </main>
 
 <?php get_footer(); ?>

--- a/single.php
+++ b/single.php
@@ -45,6 +45,8 @@ if ( function_exists( 'wsuwp_uc_get_object_type_slugs' ) && in_array( get_post_t
 	</section><!--pager-->
 </footer>
 
+	<?php get_template_part( 'parts/footers' ); ?>
+
 </main><!--/#page-->
 
 <?php get_footer(); ?>

--- a/template-builder.php
+++ b/template-builder.php
@@ -29,6 +29,8 @@ get_header();
 
 		<?php endwhile; endif; ?>
 
+		<?php get_template_part( 'parts/footers' ); ?>
+
 	</main>
 
 <?php get_footer(); ?>

--- a/templates/halves.php
+++ b/templates/halves.php
@@ -24,6 +24,9 @@
 
 </section>
 <?php endwhile; endif; ?>
+
+	<?php get_template_part( 'parts/footers' ); ?>
+
 </main>
 
 <?php get_footer(); ?>

--- a/templates/margin-left.php
+++ b/templates/margin-left.php
@@ -28,6 +28,9 @@
 
 </section>
 <?php endwhile; endif; ?>
+
+	<?php get_template_part( 'parts/footers' ); ?>
+
 </main>
 
 <?php get_footer(); ?>

--- a/templates/margin-right.php
+++ b/templates/margin-right.php
@@ -28,6 +28,9 @@
 
 </section>
 <?php endwhile; endif; ?>
+
+	<?php get_template_part( 'parts/footers' ); ?>
+
 </main>
 
 <?php get_footer(); ?>

--- a/templates/side-left.php
+++ b/templates/side-left.php
@@ -28,6 +28,9 @@
 
 </section>
 <?php endwhile; endif; ?>
+
+	<?php get_template_part( 'parts/footers' ); ?>
+
 </main>
 
 <?php get_footer(); ?>

--- a/templates/side-right.php
+++ b/templates/side-right.php
@@ -28,6 +28,9 @@
 
 </section>
 <?php endwhile; endif; ?>
+
+	<?php get_template_part( 'parts/footers' ); ?>
+
 </main>
 
 <?php get_footer(); ?>

--- a/templates/single.php
+++ b/templates/single.php
@@ -19,6 +19,9 @@
 
 </section>
 <?php endwhile; endif; ?>
+
+	<?php get_template_part( 'parts/footers' ); ?>
+
 </main>
 
 <?php get_footer(); ?>

--- a/tribe-events/default-template.php
+++ b/tribe-events/default-template.php
@@ -15,6 +15,8 @@ get_header();
 		</div>
 	</section>
 
+	<?php get_template_part( 'parts/footers' ); ?>
+
 </main>
 <?php
 


### PR DESCRIPTION
This matches the parts/headers template that is used directly
inside each `main` opener and allows us to specify a common
content footer throughout a theme.