### PR TITLE
[PR] Introduce section backgrounds in the builder interface

### DIFF
--- a/builder-templates/admin/banner.php
+++ b/builder-templates/admin/banner.php
@@ -117,6 +117,7 @@ $section_order = ( ! empty( $ttfmake_section_data['data']['banner-slide-order'] 
 				spine_output_builder_section_wrapper( $section_name, $ttfmake_section_data );
 				spine_output_builder_section_label( $section_name, $ttfmake_section_data );
 				spine_output_builder_column_classes( $section_name, $ttfmake_section_data );
+				spine_output_builder_section_background( $section_name, $ttfmake_section_data );
 				?>
 			</div>
 		</div>

--- a/builder-templates/admin/columns.php
+++ b/builder-templates/admin/columns.php
@@ -110,6 +110,7 @@ $section_order  = ( ! empty( $ttfmake_section_data['data']['columns-order'] ) ) 
 				spine_output_builder_section_classes( $section_name, $ttfmake_section_data );
 				spine_output_builder_section_wrapper( $section_name, $ttfmake_section_data );
 				spine_output_builder_section_label( $section_name, $ttfmake_section_data );
+				spine_output_builder_section_background( $section_name, $ttfmake_section_data );
 				?>
 			</div>
 		</div>

--- a/builder-templates/admin/h1-header.php
+++ b/builder-templates/admin/h1-header.php
@@ -40,6 +40,7 @@ spine_load_section_header();
 			spine_output_builder_section_classes( $section_name, $ttfmake_section_data );
 			spine_output_builder_section_wrapper( $section_name, $ttfmake_section_data );
 			spine_output_builder_section_label( $section_name, $ttfmake_section_data );
+			spine_output_builder_section_background( $section_name, $ttfmake_section_data );
 			?>
 		</div>
 	</div>

--- a/builder-templates/css/sections.css
+++ b/builder-templates/css/sections.css
@@ -105,7 +105,7 @@
 .spine-builder-overlay-wrapper {
 	position: fixed !important;
 	width: 400px;
-	height: 480px;
+	height: 520px;
 	margin-left: -200px;
 	margin-top: -200px;
 	top: 50% !important;

--- a/builder-templates/front-end/banner.php
+++ b/builder-templates/front-end/banner.php
@@ -40,8 +40,33 @@ $slider_ratio = ( $slider_height / 960 ) * 100;
 	<?php endif; ?>
 </style>
 <?php
+if ( isset( $ttfmake_section_data['background-img'] ) && ! empty( $ttfmake_section_data['background-img'] ) ) {
+	$section_background = $ttfmake_section_data['background-img'];
+} else {
+	$section_background = false;
+}
+
+if ( isset( $ttfmake_section_data['background-mobile-img'] ) && ! empty( $ttfmake_section_data['background-mobile-img'] ) ) {
+	$section_mobile_background = $ttfmake_section_data['background-mobile-img'];
+} elseif( $section_background ) {
+	$section_mobile_background = $section_background;
+} else {
+	$section_mobile_background = false;
+}
+
+if ( $section_background || $section_mobile_background ) {
+	if ( $section_wrapper_classes ) {
+		$section_wrapper_classes .= ' section-wrapper-has-background';
+	} else {
+		$section_wrapper_classes = 'section-wrapper-has-background';
+	}
+}
+
 if ( $section_wrapper_classes ) {
-	echo '<div class="' . esc_attr( $section_wrapper_classes ) . '">';
+	?><div class="<?php echo esc_attr( $section_wrapper_classes ); ?>"
+	<?php if ( $section_background ) : echo 'data-background="' . esc_url( $section_background ) . '"'; endif; ?>
+	<?php if ( $section_mobile_background ) : echo 'data-background-mobile="' . esc_url( $section_mobile_background ) . '"'; endif; ?>>
+<?php
 }
 ?>
 <section id="builder-section-<?php echo esc_attr( $ttfmake_section_data['id'] ); ?>" class="row single builder-section <?php echo $section_classes; ?> <?php echo esc_attr( ttfmake_builder_get_banner_class( $ttfmake_section_data, $ttfmake_sections ) ); ?>">

--- a/builder-templates/front-end/columns.php
+++ b/builder-templates/front-end/columns.php
@@ -28,11 +28,32 @@ if ( 'wsuwpsidebarright' === $section_type || 'wsuwpsidebarleft' === $section_ty
 	$section_layout = 'single';
 }
 
+if ( isset( $ttfmake_section_data['background-img'] ) && ! empty( $ttfmake_section_data['background-img'] ) ) {
+	$section_background = $ttfmake_section_data['background-img'];
+} else {
+	$section_background = false;
+}
+
+if ( isset( $ttfmake_section_data['background-mobile-img'] ) && ! empty( $ttfmake_section_data['background-mobile-img'] ) ) {
+	$section_mobile_background = $ttfmake_section_data['background-mobile-img'];
+} elseif( $section_background ) {
+	$section_mobile_background = $section_background;
+} else {
+	$section_mobile_background = false;
+}
+
+if ( $section_background || $section_mobile_background ) {
+	$section_classes .= ' has-section-background';
+}
+
 if ( $section_wrapper_classes ) {
 	echo '<div class="' . esc_attr( $section_wrapper_classes ) . '">';
 }
 ?>
-	<section id="builder-section-<?php echo esc_attr( $ttfmake_section_data['id'] ); ?>" class="row <?php echo esc_attr( $section_layout ); ?> <?php echo esc_attr( $section_classes ); ?>">
+	<section id="builder-section-<?php echo esc_attr( $ttfmake_section_data['id'] ); ?>"
+			 class="row <?php echo esc_attr( $section_layout ); ?> <?php echo esc_attr( $section_classes ); ?>"
+			 <?php if ( $section_background ) : echo 'data-background="' . esc_url( $section_background ) . '"'; endif; ?>
+			 <?php if ( $section_mobile_background ) : echo 'data-background-mobile="' . esc_url( $section_mobile_background ) . '"'; endif; ?>>
 		<?php
 		if ( ! empty( $data_columns ) ) {
 			foreach( $data_columns as $column ) {

--- a/builder-templates/front-end/columns.php
+++ b/builder-templates/front-end/columns.php
@@ -43,17 +43,22 @@ if ( isset( $ttfmake_section_data['background-mobile-img'] ) && ! empty( $ttfmak
 }
 
 if ( $section_background || $section_mobile_background ) {
-	$section_classes .= ' has-section-background';
+	if ( $section_wrapper_classes ) {
+		$section_wrapper_classes .= ' section-wrapper-has-background';
+	} else {
+		$section_wrapper_classes = 'section-wrapper-has-background';
+	}
 }
 
 if ( $section_wrapper_classes ) {
-	echo '<div class="' . esc_attr( $section_wrapper_classes ) . '">';
+	?><div class="<?php echo esc_attr( $section_wrapper_classes ); ?>"
+		<?php if ( $section_background ) : echo 'data-background="' . esc_url( $section_background ) . '"'; endif; ?>
+		<?php if ( $section_mobile_background ) : echo 'data-background-mobile="' . esc_url( $section_mobile_background ) . '"'; endif; ?>>
+	<?php
 }
 ?>
 	<section id="builder-section-<?php echo esc_attr( $ttfmake_section_data['id'] ); ?>"
-			 class="row <?php echo esc_attr( $section_layout ); ?> <?php echo esc_attr( $section_classes ); ?>"
-			 <?php if ( $section_background ) : echo 'data-background="' . esc_url( $section_background ) . '"'; endif; ?>
-			 <?php if ( $section_mobile_background ) : echo 'data-background-mobile="' . esc_url( $section_mobile_background ) . '"'; endif; ?>>
+			 class="row <?php echo esc_attr( $section_layout ); ?> <?php echo esc_attr( $section_classes ); ?>">
 		<?php
 		if ( ! empty( $data_columns ) ) {
 			foreach( $data_columns as $column ) {

--- a/builder-templates/front-end/h1-header.php
+++ b/builder-templates/front-end/h1-header.php
@@ -5,8 +5,34 @@ $section_classes = ( isset( $ttfmake_section_data['section-classes'] ) ) ? $ttfm
 $section_wrapper_classes = ( isset( $ttfmake_section_data['section-wrapper'] ) ) ? $ttfmake_section_data['section-wrapper'] : false;
 $column_classes = ( isset( $ttfmake_section_data['column-classes'] ) ) ? $ttfmake_section_data['column-classes'] : false;
 
+
+if ( isset( $ttfmake_section_data['background-img'] ) && ! empty( $ttfmake_section_data['background-img'] ) ) {
+	$section_background = $ttfmake_section_data['background-img'];
+} else {
+	$section_background = false;
+}
+
+if ( isset( $ttfmake_section_data['background-mobile-img'] ) && ! empty( $ttfmake_section_data['background-mobile-img'] ) ) {
+	$section_mobile_background = $ttfmake_section_data['background-mobile-img'];
+} elseif( $section_background ) {
+	$section_mobile_background = $section_background;
+} else {
+	$section_mobile_background = false;
+}
+
+if ( $section_background || $section_mobile_background ) {
+	if ( $section_wrapper_classes ) {
+		$section_wrapper_classes .= ' section-wrapper-has-background';
+	} else {
+		$section_wrapper_classes = 'section-wrapper-has-background';
+	}
+}
+
 if ( $section_wrapper_classes ) {
-	echo '<div class="' . esc_attr( $section_wrapper_classes ) . '">';
+	?><div class="<?php echo esc_attr( $section_wrapper_classes ); ?>"
+	<?php if ( $section_background ) : echo 'data-background="' . esc_url( $section_background ) . '"'; endif; ?>
+	<?php if ( $section_mobile_background ) : echo 'data-background-mobile="' . esc_url( $section_mobile_background ) . '"'; endif; ?>>
+<?php
 }
 ?>
 <section id="builder-section-<?php echo esc_attr( $ttfmake_section_data['id'] ); ?>" class="row single h1-header <?php echo esc_attr( $section_classes ); ?>">

--- a/inc/builder.php
+++ b/inc/builder.php
@@ -261,6 +261,14 @@ class Spine_Builder_Custom {
 			$clean_data['label'] = sanitize_text_field( $data['label'] );
 		}
 
+		if ( isset( $data['background-img'] ) ) {
+			$clean_data['background-img'] = esc_url_raw( $data['background-img'] );
+		}
+
+		if ( isset( $data['background-mobile-img'] ) ) {
+			$clean_data['background-mobile-img'] = esc_url_raw( $data['background-mobile-img'] );
+		}
+
 		return $clean_data;
 	}
 
@@ -340,6 +348,14 @@ class Spine_Builder_Custom {
 
 		if ( isset( $data['label'] ) ) {
 			$clean_data['label'] = sanitize_text_field( $data['label'] );
+		}
+
+		if ( isset( $data['background-img'] ) ) {
+			$clean_data['background-img'] = esc_url_raw( $data['background-img'] );
+		}
+
+		if ( isset( $data['background-mobile-img'] ) ) {
+			$clean_data['background-mobile-img'] = esc_url_raw( $data['background-mobile-img'] );
 		}
 
 		return $clean_data;
@@ -423,6 +439,14 @@ class Spine_Builder_Custom {
 
 		if ( isset( $data['label'] ) ) {
 			$clean_data['label'] = sanitize_text_field( $data['label'] );
+		}
+
+		if ( isset( $data['background-img'] ) ) {
+			$clean_data['background-img'] = esc_url_raw( $data['background-img'] );
+		}
+
+		if ( isset( $data['background-mobile-img'] ) ) {
+			$clean_data['background-mobile-img'] = esc_url_raw( $data['background-mobile-img'] );
 		}
 
 		return $clean_data;
@@ -596,6 +620,36 @@ function spine_output_builder_section_layout( $section_name, $ttfmake_section_da
 			?></select>
 		<p class="description">See the WSU Spine <a href="https://github.com/washingtonstateuniversity/WSU-spine/wiki/II.2.-Page:-Size,-Layouts,-and-Grids" target="_blank">grid layout documentation</a> for more information on section layouts.</p>
 	</div><?php
+}
+
+/**
+ * Output an input field to capture background images.
+ *
+ * @param $section_name
+ * @param $ttfmake_section_data
+ */
+function spine_output_builder_section_background( $section_name, $ttfmake_section_data ) {
+	$section_background = ( isset( $ttfmake_section_data['data']['background-img'] ) ) ? $ttfmake_section_data['data']['background-img'] : '';
+	$section_mobile_background = ( isset( $ttfmake_section_data['data']['background-img'] ) ) ? $ttfmake_section_data['data']['background-mobile-img'] : '';
+
+	?>
+	<div class="wsuwp-builder-meta" style="width: 100%; margin-top: 10px;">
+		<label for="<?php echo $section_name; ?>[background-img]">Background Image</label>
+		<input type="text"
+			   class="wsuwp-builder-section-image widefat"
+			   id="<?php echo $section_name; ?>[background-img]"
+			   name="<?php echo $section_name; ?>[background-img]"
+			   value="<?php echo $section_background; ?>" />
+		<br/>
+		<label for="<?php echo $section_name; ?>[background-mobile-img]">Mobile Background Image</label>
+		<input type="text"
+			   class="wsuwp-builder-section-image widefat"
+			   id="<?php echo $section_name; ?>[background-mobile-img]"
+			   name="<?php echo $section_name; ?>[background-mobile-img]"
+			   value="<?php echo $section_mobile_background; ?>" />
+		<p class="description">Background images on sections are an in progress feature. :)</p>
+	</div>
+<?php
 }
 
 /**


### PR DESCRIPTION
Section background and mobile background are now available fields in each section configuration.

* If a background is applied to a section, a wrapping `<div>` will be created and assigned the class `section-wrapper-has-background`.
* The background image(s) will be applied via data attributes `data-background-img` and `data-background-mobile-img`.
* At first the only way to access these will be via custom Javascript. In the future, we may have a broader solution available.