### PR TITLE
[PR] Filter classes in the Spine navigation to add current and dogeared

### DIFF
--- a/includes/theme-navigation.php
+++ b/includes/theme-navigation.php
@@ -15,6 +15,7 @@ class Spine_Theme_Navigation {
 		// Filters for navigation handled by BU Navigation.
 		add_filter( 'bu_navigation_filter_pages', array( $this, 'bu_filter_page_urls' ), 11 );
 		add_filter( 'bu_navigation_filter_anchor_attrs', array( $this, 'bu_filter_anchor_attrs' ), 10, 1 );
+		add_filter( 'bu_navigation_filter_item_attrs', array( $this, 'bu_navigation_filter_item_attrs' ), 10, 2 );
 	}
 
 	/**
@@ -105,6 +106,26 @@ class Spine_Theme_Navigation {
 		$attrs['title'] = '';
 
 		return $attrs;
+	}
+
+	/**
+	 * Filter the list item classes to manually add current and dogeared when necessary.
+	 *
+	 * @param array   $item_classes List of classes assigned to the list item.
+	 * @param WP_Post $page         Post object for the current page.
+	 *
+	 * @return array
+	 */
+	public function bu_navigation_filter_item_attrs( $item_classes, $page ) {
+		if ( in_array( 'current_page_item', $item_classes ) || in_array( 'current_page_parent', $item_classes ) ) {
+			$item_classes[] = 'current';
+		}
+
+		if ( is_singular() && get_the_ID() == $page->ID ) {
+			$item_classes[] = 'dogeared';
+		}
+
+		return $item_classes;
 	}
 }
 new Spine_Theme_Navigation();


### PR DESCRIPTION
We've used this previously in the College of Business and WSU Home themes. Needed to highlight the current item in the nav menu when using BU Navigation.