### PR TITLE
[PR] Add a site's domain and root path as body classes

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -480,6 +480,39 @@ function spine_is_sub() {
 	}
 }
 
+add_filter( 'body_class', 'spine_site_body_class');
+/**
+ * Add body classes for the site domain and path to help with targeting on multiple
+ * sites using this theme.
+ *
+ * @param array $classes
+ *
+ * @return array
+ */
+function spine_site_body_class( $classes ) {
+	if ( ! function_exists( 'wsuwp_get_current_site' ) ) {
+		return $classes;
+	}
+
+	$site = wsuwp_get_current_site();
+	$site_domain = 'domain-' . sanitize_title_with_dashes( $site->domain );
+	$site_path = 'path-' . sanitize_title_with_dashes( $site->path );
+
+	if ( 'path-' === $site_path ) {
+		$site_path = 'path-none';
+	}
+
+	if ( ! isset( $classes[ $site_domain ] ) ) {
+		$classes[] = $site_domain;
+	}
+
+	if ( ! isset( $classes[ $site_path ] ) ) {
+		$classes[] = $site_path;
+	}
+
+	return $classes;
+}
+
 add_filter( 'body_class', 'spine_open_sans_body_class' );
 /**
  * If Open Sans has been applied to the Spine, add the


### PR DESCRIPTION
This will aid in using the same stylesheet across multiple sites, especially when a child theme is in use. In the future, we may also have the ability to share custom CSS across sites on a network.

* If on a root site (e.g. mysite.wsu.edu/), the domain class will be `domain-mysite-wsu-edu` and the path class will be `path-none`.
* If on a page on the root site, the domain and path classes will still be `domain-mysite-wsu-edu` and `path-none`.
* If a subsite has been created (e.g. mysite.wsu.edu/site2/), the domain class will be `domain-mysite-wsu-edu` and the path class will be `path-site2`.
* If on a page on the sub site, the domain and path classes will still be `domain-mysite-wsu-edu` and `path-site2`.