### PR TITLE
Wrap main body like main header and main footer

### DIFF
--- a/parts/archive-layout.php
+++ b/parts/archive-layout.php
@@ -1,3 +1,5 @@
+<div class="main-body">
+
 <section class="row side-right gutter pad-ends">
 
 	<div class="column one">
@@ -17,3 +19,5 @@
 	</div><!--/column two-->
 
 </section>
+
+</div><!--/main-body-->

--- a/parts/single-layout.php
+++ b/parts/single-layout.php
@@ -1,3 +1,5 @@
+<div class="main-body">
+
 <section class="row side-right gutter pad-ends">
 
 	<div class="column one">
@@ -17,3 +19,5 @@
 	</div><!--/column two-->
 
 </section>
+
+</div><!--/main-body-->


### PR DESCRIPTION
We wrap main header and main footer making it easy to target elements
that may be used elsewhere in `main` like `section`, `a`, etc. Adding a
parallel wrapper to the body enables us to target the content area of a
page without fighting with classes applied to the header and footer.