### PR TITLE
[PR] Provide a filter to override the campus home URL

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -81,7 +81,7 @@ function spine_get_campus_home_url() {
 		return esc_url( $campus_urls[ $campus_location ] );
 	}
 
-	return 'https://wsu.edu/';
+	return apply_filters( 'spine_get_campus_home_url', 'https://wsu.edu/' );
 }
 
 /**


### PR DESCRIPTION
This will allow very unique sites like Foundation to override the
wsu.edu URL without requiring placement as a campus location.

In the future, this may also allow for interesting possibilities
in Spine usage without the WSU branding. That's less likely.