### PR TITLE
[PR] Add a check for empty background and featured images before output

### DIFF
--- a/parts/featured-images.php
+++ b/parts/featured-images.php
@@ -1,18 +1,21 @@
 <?php
 
-// If a featured image is assigned to the post, display as a background image.
-
+// If a background image is assigned to the post, attach it as a background to jacket.
 if ( spine_has_background_image() ) {
 	$background_image_src = spine_get_background_image_src();
-	?>
 
-	<style> #jacket { background-image: url(<?php echo esc_url( $background_image_src ); ?>); }</style>
+	// The image cannot be empty.
+	if ( ! empty( trim( $background_image_src ) ) ) {
+		?><style> #jacket { background-image: url(<?php echo esc_url( $background_image_src ); ?>); }</style><?php
+	}
+}
 
-<?php } ?>
+// If a featured image is assigned to the post, output it as a figure with a background image accordingly.
+if ( spine_has_featured_image() ) {
+	$featured_image_src = spine_get_featured_image_src();
 
-<?php if ( spine_has_featured_image() ) {
-$featured_image_src = spine_get_featured_image_src(); ?>
-<figure class="featured-image" style="background-image: url('<?php echo $featured_image_src ?>');">
-	<?php spine_the_featured_image(); ?>
-</figure>
-<?php } ?>
+	// The image cannot be empty.
+	if ( ! empty( trim( $featured_image_src ) ) ) {
+		?><figure class="featured-image" style="background-image: url('<?php echo $featured_image_src ?>');"><?php spine_the_featured_image(); ?></figure><?php
+	}
+}


### PR DESCRIPTION
It was possible (I think) for an non-existing image to be assigned
as a featured image to a post somehow. This may be due to import
from another WordPress installation. In these cases, an empty
string is returned when we retrieve the featured image source. We
can get around this by checking for a value before outputting any
HTML for the image.