### PR TITLE
[PR] Process section background images into actual background images

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -413,6 +413,9 @@ function spine_wp_enqueue_scripts() {
 			wp_enqueue_style( 'genericons', get_template_directory_uri() . '/styles/genericons/genericons.css', array(), spine_get_script_version() );
 		}
 	}
+
+	// Enqueue scripting for the entire parent theme.
+	wp_enqueue_script( 'wsu-spine-theme-js', get_template_directory_uri() . '/js/spine-theme.js', array( 'jquery' ), spine_get_script_version(), true );
 }
 
 add_action( 'admin_enqueue_scripts', 'spine_admin_enqueue_scripts' );

--- a/js/spine-theme.js
+++ b/js/spine-theme.js
@@ -1,0 +1,18 @@
+(function($,window){
+	/**
+	 * Look for any sections with background images stored as data attributes
+	 * and convert the data attribute into inline CSS for that section.
+	 */
+	process_section_backgrounds = function() {
+		var $bg_sections = $('.section-wrapper-has-background');
+
+		$bg_sections.each( function() {
+			var background_image = $(this).data('background');
+			$(this).css('background-image', 'url(' + background_image + ')' );
+		});
+	};
+
+	$(document).ready( function() {
+		process_section_backgrounds();
+	});
+}(jQuery,window));


### PR DESCRIPTION
If a background image is assigned to a section, it will now be processed into inline CSS for that section after the page loads.

Fixes #203 