### PR TITLE
[PR] Provide the X-UA-Compatible header in the HTML document

### DIFF
--- a/header.php
+++ b/header.php
@@ -4,7 +4,7 @@
 <!--[if IE 8]><html class="no-js no-svg lt-ie9" lang="en"> <![endif]-->
 <!--[if gt IE 8]><!--><html class="no-js" <?php language_attributes(); ?>><!--<![endif]-->
 <head>
-
+	<meta http-equiv="X-UA-Compatible" content="IE=EDGE">
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />
 	<title><?php echo esc_html( spine_get_title() ); ?></title>
 


### PR DESCRIPTION
This apparently resolves a long standing IE compatibility mode
issue because IE is appearing to ignore the header sent by the
server.