### PR TITLE
[PR] Set main header with to 100% at size-small

### DIFF
--- a/styles/bookmark.css
+++ b/styles/bookmark.css
@@ -56,6 +56,11 @@ body.home:not(.has-background-image) #jacket {
 .size-small.spacing-loose .main-header .header-group {
 	padding: 2rem 0 1.1rem 4rem;
 	}
+
+.size-small .style-bookmark .main-header {
+	width: 100%;
+}
+
 .sup-header-default,
 .sub-header-default {
 	display: block;

--- a/styles/bookmark.css
+++ b/styles/bookmark.css
@@ -57,7 +57,7 @@ body.home:not(.has-background-image) #jacket {
 	padding: 2rem 0 1.1rem 4rem;
 	}
 
-.size-small .style-bookmark .main-header {
+.size-small .main-header {
 	width: 100%;
 }
 

--- a/styles/bookmark.css
+++ b/styles/bookmark.css
@@ -48,7 +48,7 @@ body.home:not(.has-background-image) #jacket {
 	padding: 2rem 0 1.1rem 1.3rem;
 	}
 .size-small .main-header .header-group {
-	padding: 2rem 0 1.1rem 2rem;
+	padding: 2rem 1rem 1.1rem 1rem;
 	}
 .size-small.spacing-tight .main-header .header-group {
 	padding: 2rem 0 1.1rem 1rem;


### PR DESCRIPTION
At this point, the main header is flushed left and no longer needs to be forced to 2000px to aid with spacing.

Fixes #81.