### PR TITLE
[PR] Balance tags when generating a custom excerpt.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -488,6 +488,8 @@ function spine_trim_excerpt( $text ) {
 		} else {
 			$text = implode( ' ', $words );
 		}
+
+		$text = force_balance_tags( $text );
 	}
 	return apply_filters( 'wp_trim_excerpt', $text, $raw_excerpt );
 }


### PR DESCRIPTION
The default excerpt functionality in WordPress strips all tags via `wp_trim_words()` as no tags are allowed in excerpts. Because we whitelist a set of tags, we need to account for them being unbalanced after trim. Unbalanced tags create super strange page views... :)