### PR TITLE
[PR] Set `false` as the default for bleed left in the Spine

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -105,7 +105,7 @@ function spine_get_option_defaults() {
 		'articletitle_show'         => true,
 		'articletitle_header'       => false,
 		'broken_binding'            => false,
-		'bleed'                     => true,
+		'bleed'                     => false,
 		'search_state'              => 'closed',
 		'crop'                      => false,
 		'spineless'                 => false,


### PR DESCRIPTION
This appears to have been an accidental change as part of another
commit in 83217097d966cd637bd3

Fixes #243