### PR TITLE
[PR] Remove print tab from Spine header area

### DIFF
--- a/spine/header.php
+++ b/spine/header.php
@@ -8,7 +8,6 @@
 		<li id="wsu-search-tab" class="spine-search-tab closed"><button>Search</button></li>
 		<li id="wsu-contact-tab" class="spine-contact-tab closed"><button>Contact</button></li>
 		<li id="wsu-share-tab" class="spine-share-tab closed"><button>Share</button></li>
-		<li id="wsu-print-tab" class="spine-print-tab closed"><button>Print</button></li>
 	</ul>
 
 </section><!--/#wsu-actions-->

--- a/style.css
+++ b/style.css
@@ -521,3 +521,7 @@ article.wsuwp_uc_person {
 	line-height: 1.5;
 	float: left;
 }
+
+#spine .spine-actions>ul li {
+	width: 33%;
+}


### PR DESCRIPTION
We've decided that this doesn't need to be a part of all layouts in the primary parent theme.