### PR TITLE
[PR] Clear elements above `.article-footer`

### DIFF
--- a/style.css
+++ b/style.css
@@ -254,6 +254,7 @@ article footer a:hover {
 
 .article-footer {
 	position: relative;
+	clear: both;
 }
 
 .article-footer .categorized dt:after,


### PR DESCRIPTION
If a floating element exists in a small article, it can overlap
with the article footer unless we clear the float