### PR TITLE
[PR] Banner revisions

### DIFF
--- a/builder-templates/front-end/banner.php
+++ b/builder-templates/front-end/banner.php
@@ -129,12 +129,12 @@ if ( '' === $section_id ) {
 					<?php if ( ! empty( $slide['slide-url'] ) ) : ?></a><?php endif; ?>
 				</div>
 			<?php endforeach; endif; ?>
+			<?php if ( $is_slider && false === (bool) $ttfmake_section_data['hide-dots'] ) : ?>
+				<div class="cycle-pager"></div>
+			<?php endif; ?>
 			<?php if ( $is_slider && false === (bool) $ttfmake_section_data['hide-arrows'] ) : ?>
 				<div class="cycle-prev"></div>
 				<div class="cycle-next"></div>
-			<?php endif; ?>
-			<?php if ( $is_slider && false === (bool) $ttfmake_section_data['hide-dots'] ) : ?>
-				<div class="cycle-pager"></div>
 			<?php endif; ?>
 		</div>
 	</div>

--- a/builder-templates/front-end/banner.php
+++ b/builder-templates/front-end/banner.php
@@ -111,7 +111,7 @@ if ( '' === $section_id ) {
 
 		<div class="builder-section-content<?php echo ( $is_slider ) ? ' cycle-slideshow' : ''; ?>"<?php echo ( $is_slider ) ? ttfmake_builder_get_banner_slider_atts( $ttfmake_section_data ) : ''; ?>>
 			<?php if ( ! empty( $banner_slides ) ) : $i = 0; foreach ( $banner_slides as $slide ) : ?>
-				<div class="builder-banner-slide<?php echo ttfmake_builder_banner_slide_class( $slide ); echo ( $i++ == 0 ) ? ' first-slide' : ''; ?>" style="<?php echo ttfmake_builder_banner_slide_style( $slide, $ttfmake_section_data ); ?>">
+				<div class="builder-banner-slide<?php echo ttfmake_builder_banner_slide_class( $slide ); echo ( 0 == $i++ ) ? ' first-slide' : ''; ?>" style="<?php echo ttfmake_builder_banner_slide_style( $slide, $ttfmake_section_data ); ?>">
 					<?php if ( ! empty( $slide['slide-url'] ) ) : ?><a href="<?php echo esc_url( $slide['slide-url'] ); ?>"><?php endif; ?>
 					<div class="builder-banner-content">
 						<?php if ( ! empty( $slide['slide-title'] ) ) : ?>

--- a/builder-templates/front-end/banner.php
+++ b/builder-templates/front-end/banner.php
@@ -110,8 +110,8 @@ if ( '' === $section_id ) {
 		<?php endif; ?>
 
 		<div class="builder-section-content<?php echo ( $is_slider ) ? ' cycle-slideshow' : ''; ?>"<?php echo ( $is_slider ) ? ttfmake_builder_get_banner_slider_atts( $ttfmake_section_data ) : ''; ?>>
-			<?php if ( ! empty( $banner_slides ) ) : foreach ( $banner_slides as $slide ) : ?>
-				<div class="builder-banner-slide<?php echo ttfmake_builder_banner_slide_class( $slide ); ?>" style="<?php echo ttfmake_builder_banner_slide_style( $slide, $ttfmake_section_data ); ?>">
+			<?php if ( ! empty( $banner_slides ) ) : $i = 0; foreach ( $banner_slides as $slide ) : ?>
+				<div class="builder-banner-slide<?php echo ttfmake_builder_banner_slide_class( $slide ); echo ( $i++ == 0 ) ? ' first-slide' : ''; ?>" style="<?php echo ttfmake_builder_banner_slide_style( $slide, $ttfmake_section_data ); ?>">
 					<?php if ( ! empty( $slide['slide-url'] ) ) : ?><a href="<?php echo esc_url( $slide['slide-url'] ); ?>"><?php endif; ?>
 					<div class="builder-banner-content">
 						<?php if ( ! empty( $slide['slide-title'] ) ) : ?>

--- a/style.css
+++ b/style.css
@@ -404,7 +404,14 @@ article footer a:hover {
 	border-right-width: 8rem;
 	box-sizing: border-box;
 	color: #fff;
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
 	display: flex;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-webkit-flex-direction: column;
+	-ms-flex-direction: column;
 	flex-direction: column;
 	height: 100%;
 	line-height: 1.35;
@@ -425,9 +432,22 @@ article footer a:hover {
 }
 
 .builder-banner-inner-content {
+	display: -webkit-box;
+	display: -webkit-flex;
+	display: -ms-flexbox;
 	display: flex;
+	-webkit-box-flex: 1;
+	-webkit-flex: 1;
+	-ms-flex: 1;
 	flex: 1;
+	-webkit-box-orient: vertical;
+	-webkit-box-direction: normal;
+	-webkit-flex-direction: column;
+	-ms-flex-direction: column;
 	flex-direction: column;
+	-webkit-box-pack: center;
+	-webkit-justify-content: center;
+	-ms-flex-pack: center;
 	justify-content: center;
 	overflow: hidden;
 	font-size: 1rem;

--- a/style.css
+++ b/style.css
@@ -396,6 +396,11 @@ article footer a:hover {
 	background-repeat: no-repeat;
 	background-position: center center;
 	background-size: cover;
+	display: none;
+}
+
+.builder-banner-slide.first-slide {
+	display: block;
 }
 
 .builder-banner-content {

--- a/style.css
+++ b/style.css
@@ -406,7 +406,6 @@ article footer a:hover {
 	color: #fff;
 	display: flex;
 	flex-direction: column;
-	font-size: 0;
 	height: 100%;
 	line-height: 1.35;
 	left: 0;
@@ -432,10 +431,6 @@ article footer a:hover {
 	justify-content: center;
 	overflow: hidden;
 	font-size: 1rem;
-}
-/* Might help in cases where there is too much content in a slide. */
-.builder-banner-inner-content * {
-	display: flex;
 }
 
 .builder-section-banner .cycle-pager {

--- a/style.css
+++ b/style.css
@@ -485,6 +485,11 @@ article footer a:hover {
 	top: 50%;
 	cursor: pointer;
 	height: 4rem;
+	margin-top: -2rem;
+}
+
+.builder-section-banner .cycle-pager ~ .cycle-prev,
+.builder-section-banner .cycle-pager ~ .cycle-next {
 	margin-top: -4rem;
 }
 
@@ -516,7 +521,8 @@ article footer a:hover {
 		background-color: rgba(0, 0, 0, .4);
 	}
 
-	.builder-section-banner .cycle-prev, .builder-section-banner .cycle-next {
+	.builder-section-banner .cycle-prev,
+	.builder-section-banner .cycle-next {
 		opacity: .6;
 	}
 


### PR DESCRIPTION
- Removes the `.builder-banner-inner-content *` rule, as it was the most common culprit in breaking custom slideshow styling and would only be of value in cases where a slide has too much content anyway.
- Removes the unnecessary `font-size: 0;` declaration in the `builder-banner-content` class
- Adds prefixes for the Flexbox rules.
- Hides all but first slide on page load*.
- Adjusts positioning of the previous and next controls if the navigation dots are not in use*.

*These will only take effect on existing slideshows after they've been updated.