### PR TITLE
[PR] Remove inline height after a section has been toggled open

### DIFF
--- a/inc/builder/core/js/views/section.js
+++ b/inc/builder/core/js/views/section.js
@@ -79,6 +79,7 @@ var oneApp = oneApp || {}, $oneApp = $oneApp || jQuery(oneApp);
 					paddingBottom: '20px',
 					paddingTop: '20px'
 				}, oneApp.options.openSpeed, function() {
+					$sectionBody.css( "height", "auto" );
 					$section.addClass('ttfmake-section-open');
 					$input.val('open');
 				});

--- a/inc/builder/core/js/views/section.js
+++ b/inc/builder/core/js/views/section.js
@@ -79,7 +79,7 @@ var oneApp = oneApp || {}, $oneApp = $oneApp || jQuery(oneApp);
 					paddingBottom: '20px',
 					paddingTop: '20px'
 				}, oneApp.options.openSpeed, function() {
-					$sectionBody.css( "height", "auto" );
+					$sectionBody.css('height', 'auto');
 					$section.addClass('ttfmake-section-open');
 					$input.val('open');
 				});


### PR DESCRIPTION
Fixes a bug where collapsed columns within a toggled section would be inaccessible when opened due to the parent section height being fixed, therefore not expanding with it.

@jeremyfelt #reviewmerge?