### PR TITLE
[PR] Introduce 'screen-reader-text' class styles

### DIFF
--- a/style.css
+++ b/style.css
@@ -734,3 +734,13 @@ article.wsuwp_uc_person {
 	top: 0;
 	width: 100%;
 }
+
+/** Default WP widget screen reader text */
+.screen-reader-text {
+	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	overflow: hidden;
+	position: absolute !important;
+	width: 1px;
+	word-wrap: normal !important;
+}


### PR DESCRIPTION
As bought up in Open Lab, some of WordPress's default widgets (Search and Categories, to name two) have elements which leverage this class, but with no styling in place, those elements are currently visible.

@jeremyfelt #reviewmerge?