### PR TITLE
[PR] Provide title options for front page and page for posts

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -151,6 +151,8 @@ function spine_get_option_defaults() {
 		'social_spot_four'          => 'http://social.wsu.edu',
 		'post_social_placement'     => 'none',
 		'show_author_page'          => '1',
+		'front_page_title'          => false,
+		'page_for_posts_title'      => false,
 	);
 }
 

--- a/includes/theme-customizer.php
+++ b/includes/theme-customizer.php
@@ -116,6 +116,35 @@ class Spine_Theme_Customizer {
 			),
 		) );
 
+		// Front Page
+		$wp_customize->add_setting( 'spine_options[front_page_title]', array(
+			'default' => false,
+			'capability' => 'edit_theme_options',
+			'type' => 'option',
+		) );
+
+		$wp_customize->add_control( 'spine_options[front_page_title]', array(
+			'label' => 'Show title on front page',
+			'section' => 'static_front_page',
+			'settings' => 'spine_options[front_page_title]',
+			'type' => 'checkbox',
+			'active_callback' => function() { return 'page' == get_option( 'show_on_front' ); },
+		) );
+
+		$wp_customize->add_setting( 'spine_options[page_for_posts_title]', array(
+			'default' => false,
+			'capability' => 'edit_theme_options',
+			'type' => 'option',
+		) );
+
+		$wp_customize->add_control( 'spine_options[page_for_posts_title]', array(
+			'label' => 'Show title on posts page',
+			'section' => 'static_front_page',
+			'settings' => 'spine_options[page_for_posts_title]',
+			'type' => 'checkbox',
+			'active_callback' => function() { return 'page' == get_option( 'show_on_front' ); },
+		) );
+
 		// Signature
 		$wp_customize->add_setting( 'spine_options[campus_location]', array(
 			'default'    => '',

--- a/js/customizer.js
+++ b/js/customizer.js
@@ -25,4 +25,20 @@
 		});
 
 	});
+
+	/**
+	 * Toggle the display of the options to show a front page title or posts page title. These
+	 * options should only appear when a static page is selected as the option for Front Page.
+	 */
+	wp.customize( 'show_on_front', function( setting ) {
+		setting.bind( function( value )  {
+			if ( 'page' === value ) {
+				$('#customize-control-spine_options-front_page_title').show();
+				$('#customize-control-spine_options-page_for_posts_title').show();
+			} else {
+				$('#customize-control-spine_options-page_for_posts_title').hide();
+				$('#customize-control-spine_options-front_page_title').hide();
+			}
+		});
+	} );
 }(jQuery));

--- a/parts/headers.php
+++ b/parts/headers.php
@@ -31,3 +31,29 @@ if ( true === spine_get_option( 'main_header_show' ) ) :
 
 <?php
 endif;
+
+if ( is_front_page() && ! is_home() &&  true === spine_get_option( 'front_page_title' ) ) :
+?>
+<section class="row single gutter pad-ends">
+	<div class="column one">
+		<h1><?php the_title(); ?></h1>
+	</div>
+</section>
+<?php
+endif;
+
+if ( is_home() && ! is_front_page() && true === spine_get_option( 'page_for_posts_title' ) ) :
+	$page_for_posts_id = get_option( 'page_for_posts' );
+	if ( $page_for_posts_id ) {
+		$page_for_posts_title = get_the_title( $page_for_posts_id );
+	} else {
+		$page_for_posts_title = '';
+	}
+	?>
+<section class="row single gutter pad-ends">
+	<div class="column one">
+		<h1><?php echo esc_html( $page_for_posts_title ); ?></h1>
+	</div>
+</section>
+<?php
+endif;

--- a/parts/headers.php
+++ b/parts/headers.php
@@ -32,7 +32,7 @@ if ( true === spine_get_option( 'main_header_show' ) ) :
 <?php
 endif;
 
-if ( is_front_page() && ! is_home() &&  true === spine_get_option( 'front_page_title' ) ) :
+if ( is_front_page() && ! is_home() && true === spine_get_option( 'front_page_title' ) ) :
 ?>
 <section class="row single gutter pad-ends">
 	<div class="column one">


### PR DESCRIPTION
When pages are selected to display as the front page and as the
page for the main posts archive, we should provide a way for those
page titles to display.

This shows options in the customizer for each. These options only
display when static pages are selected. The titles are off by default
to match current behavior and will display when the boxes are checked.