### PR TITLE
[PR] Correct situational troubles with wpautop and content syndication

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -499,11 +499,11 @@ function spine_trim_excerpt( $text ) {
 		//Delete all shortcode tags from the content.
 		$text = strip_shortcodes( $text );
 
+		$allowed_tags = '<p>,<a>,<em>,<strong>,<img>,<h2>,<h3>,<h4>,<h5>';
+		$text = strip_tags( $text, $allowed_tags );
+
 		$text = apply_filters( 'the_content', $text );
 		$text = str_replace( ']]>', ']]&gt;', $text );
-
-		$allowed_tags = '<p>,<a>,<em>,<strong>,<img>';
-		$text = strip_tags( $text, $allowed_tags );
 
 		$excerpt_word_count = 105;
 		$excerpt_length = apply_filters( 'excerpt_length', $excerpt_word_count );

--- a/functions.php
+++ b/functions.php
@@ -503,6 +503,11 @@ function spine_trim_excerpt( $text ) {
 		$text = strip_tags( $text, $allowed_tags );
 
 		$text = apply_filters( 'the_content', $text );
+
+		if ( ! has_filter( 'the_content', 'wpautop' ) ) {
+			$text = wpautop( $text );
+		}
+
 		$text = str_replace( ']]>', ']]&gt;', $text );
 
 		$excerpt_word_count = 105;

--- a/functions.php
+++ b/functions.php
@@ -499,7 +499,7 @@ function spine_trim_excerpt( $text ) {
 		//Delete all shortcode tags from the content.
 		$text = strip_shortcodes( $text );
 
-		$allowed_tags = '<p>,<a>,<em>,<strong>,<img>,<h2>,<h3>,<h4>,<h5>';
+		$allowed_tags = '<p>,<a>,<em>,<strong>,<img>,<h2>,<h3>,<h4>,<h5>,<blockquote>';
 		$text = strip_tags( $text, $allowed_tags );
 
 		$text = apply_filters( 'the_content', $text );

--- a/functions.php
+++ b/functions.php
@@ -854,3 +854,24 @@ function spine_get_title() {
 
 	return apply_filters( 'spine_get_title', $title, $site_part, $global_part, $view_title );
 }
+
+/**
+ * Run an individual content syndicate item through wpautop. This is attached through
+ * the page builder template, which normally removes the use of wpautop completely so
+ * that it can process its sections.
+ *
+ * @param $subset
+ * @param $post
+ * @param $atts
+ *
+ * @return mixed
+ */
+function spine_filter_local_content_syndicate_item( $subset, $post, $atts ) {
+	if ( ! isset( $atts['scheme'] ) || 'local' !== $atts['scheme'] ) {
+		return $subset;
+	}
+
+	$subset->content = wpautop( $subset->content );
+
+	return $subset;
+}

--- a/template-builder.php
+++ b/template-builder.php
@@ -21,7 +21,9 @@ get_header();
 				 * survive the process and to avoid autop issues.
 				 */
 				remove_filter( 'the_content', 'wpautop', 10 );
+				add_filter( 'wsu_content_syndicate_host_data', 'spine_filter_local_content_syndicate_item', 10, 3 );
 				the_content();
+				remove_filter( 'wsu_content_syndicate_host_data', 'spine_filter_local_content_syndicate_item', 10 );
 				add_filter( 'the_content', 'wpautop', 10 );
 
 				?>


### PR DESCRIPTION
* Strip non-allowed tags from excerpts **before** running the excerpt through `the_content` filters so that proper paragraphs are built.
* Allow heading tags - h2, h3, h4, h5 in excerpts.
* Filter local content syndicate items to make sure that `wpautop` is run properly on the full text when output as part of the page builder template.