### PR TITLE
[PR] Update PHPCS and adjust default configuration to match

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
     }
   ],
   "require-dev": {
-    "squizlabs/php_codesniffer": "2.3.4",
-    "wp-coding-standards/wpcs": "0.8.0"
+    "squizlabs/php_codesniffer": "2.5.1",
+    "wp-coding-standards/wpcs": "0.9.0"
   },
   "scripts": {
     "post-install-cmd": "\"vendor/bin/phpcs\" --config-set installed_paths vendor/wp-coding-standards/wpcs",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/washingtonstateuniversity/wsuwp-spine-parent-theme"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
+    "grunt": "~1.0.1",
     "grunt-phpcs": "^0.4.0"
   }
 }

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -4,12 +4,14 @@
 
     <rule ref="WordPress-Extra">
         <exclude name="WordPress.NamingConventions.ValidFunctionName" />
+        <exclude name="WordPress.NamingConventions.ValidVariableName" />
         <exclude name="WordPress.Files.FileName" />
         <exclude name="WordPress.XSS.EscapeOutput" />
         <exclude name="WordPress.CSRF.NonceVerification" />
         <exclude name="Generic.Formatting.DisallowMultipleStatements" />
         <exclude name="Generic.WhiteSpace.ScopeIndent" />
         <exclude name="WordPress.PHP.StrictComparisons" />
+        <exclude name="WordPress.PHP.StrictInArray" />
         <exclude name="WordPress.WP.EnqueuedResources" />
         <exclude name="WordPress.WP.PreparedSQL" />
     </rule>


### PR DESCRIPTION
There are still some things in the Spine Parent that aren't worth
it to scan for after the fork from upstream Make.