### PR TITLE
[PR] Bump the z-index on the builder overlays

### DIFF
--- a/inc/builder/core/css/builder.css
+++ b/inc/builder/core/css/builder.css
@@ -419,7 +419,7 @@
 	bottom: 0;
 	text-align: center;
 	white-space: nowrap;
-	z-index: 99999;
+	z-index: 100200;
 	position: fixed;
 }
 .spine-builder-column-overlay:before,


### PR DESCRIPTION
Elements from TinyMCE on previously active sections are playing strangely and will sometimes appear above the overlay. This corrects the immediate issue, though it will be nice to fix the underlying one as well.