### PR TITLE
[PR] Provide and use `spine_get_child_version()`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -336,7 +336,7 @@ function spine_wp_enqueue_scripts() {
 		} else {
 			$child_stylesheet = 'style.css';
 		}
-		wp_enqueue_style( 'spine-theme-child', get_stylesheet_directory_uri() . '/' . $child_stylesheet, array( 'wsu-spine' ), spine_get_script_version() );
+		wp_enqueue_style( 'spine-theme-child', get_stylesheet_directory_uri() . '/' . $child_stylesheet, array( 'wsu-spine' ), spine_get_child_version() );
 	} else {
 		wp_enqueue_style( 'spine-theme',       get_template_directory_uri()   . '/style.css', array( 'wsu-spine' ), spine_get_script_version() );
 		if ( 'skeletal' !== spine_get_option( 'theme_style' ) ) {
@@ -955,4 +955,15 @@ function page_body_class( $classes ) {
 	}
 
 	return $classes;
+}
+
+/**
+ * Return a version number that can be used to help break cache on child themes.
+ *
+ * @since 0.26.15
+ *
+ * @return string
+ */
+function spine_get_child_version() {
+	return apply_filters( 'spine_child_theme_version', spine_get_script_version() );
 }


### PR DESCRIPTION
This allows child themes to provide a version number that can be used when enqueuing their stylesheets automatically in the parent theme.