### PR TITLE
Use `get_site()` vs `wsuwp_get_current_site()`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -547,11 +547,11 @@ add_filter( 'body_class', 'spine_site_body_class' );
  * @return array
  */
 function spine_site_body_class( $classes ) {
-	if ( ! function_exists( 'wsuwp_get_current_site' ) ) {
+	if ( ! is_multisite() ) {
 		return $classes;
 	}
 
-	$site = wsuwp_get_current_site();
+	$site = get_site();
 	$site_domain = 'domain-' . sanitize_title_with_dashes( $site->domain );
 	$site_path = 'path-' . sanitize_title_with_dashes( $site->path );
 


### PR DESCRIPTION
The previous was a poort attempt at a wrapper just for the purpose
of better naming. Now that `get_site()` is avaialble in core, we
can get rid of it.

See https://github.com/washingtonstateuniversity/WSUWP-Platform/issues/351