### PR TITLE
[PR] Add basic support for the breadcrumb-navxt plugin

### DIFF
--- a/parts/headers.php
+++ b/parts/headers.php
@@ -32,6 +32,12 @@ if ( true === spine_get_option( 'main_header_show' ) ) :
 <?php
 endif;
 
+if ( ! is_front_page() && ! is_home() && function_exists( 'bcn_display' ) ) {
+	?><section class="row single breadcrumbs gutter pad-top" typeof="BreadcrumbList" vocab="http://schema.org/">
+		<div class="column one"><?php bcn_display(); ?></div>
+	</section><?php
+}
+
 if ( is_front_page() && ! is_home() && true === spine_get_option( 'front_page_title' ) ) :
 ?>
 <section class="row single gutter pad-ends">


### PR DESCRIPTION
This adds support for [Breadcrumb NavXT](https://wordpress.org/plugins/breadcrumb-navxt/), which will be added to the WSU public plugins list shortly.