### PR TITLE
[PR] Remove Crimson as a color option for the Spine

### DIFF
--- a/includes/theme-customizer.php
+++ b/includes/theme-customizer.php
@@ -180,7 +180,6 @@ class Spine_Theme_Customizer {
 			'white'    => 'White',
 			'dark'     => 'Dark',
 			'darker'   => 'Darker',
-			'crimson'  => 'Crimson',
 		);
 
 		/**
@@ -188,6 +187,11 @@ class Spine_Theme_Customizer {
 		 * selected a deprecated option, we'll continue to offer it.
 		 */
 		$current_color = spine_get_option( 'spine_color' );
+
+		if ( 'crimson' === $current_color ) {
+			$spine_colors['crimson'] = 'Crimson';
+		}
+
 		if ( 'lightest' === $current_color ) {
 			$spine_colors['lightest'] = 'Lightest';
 		}


### PR DESCRIPTION
If crimson is already set as a color option, then we'll continue to present it until it is changed.

This change is being made as part of an accessibility effort.