### PR TITLE
[PR] Provide filters to disable additional featured images

### DIFF
--- a/includes/theme-images.php
+++ b/includes/theme-images.php
@@ -54,17 +54,25 @@ class Spine_Theme_Images {
 			'id' => 'thumbnail-image',
 		);
 
-		$background_args['post_type'] = 'post';
-		new MultiPostThumbnails( $background_args );
+		if ( true === apply_filters( 'spine_post_supports_background_image', true ) ) {
+			$background_args['post_type'] = 'post';
+			new MultiPostThumbnails( $background_args );
+		}
 
-		$background_args['post_type'] = 'page';
-		new MultiPostThumbnails( $background_args );
+		if ( true === apply_filters( 'spine_page_supports_background_image', true ) ) {
+			$background_args['post_type'] = 'page';
+			new MultiPostThumbnails( $background_args );
+		}
 
-		$thumbnail_args['post_type'] = 'post';
-		new MultiPostThumbnails( $thumbnail_args );
+		if ( true === apply_filters( 'spine_post_supports_thumbnail_image', true ) ) {
+			$thumbnail_args['post_type'] = 'post';
+			new MultiPostThumbnails( $thumbnail_args );
+		}
 
-		$thumbnail_args['post_type'] = 'page';
-		new MultiPostThumbnails( $thumbnail_args );
+		if ( true === apply_filters( 'spine_page_supports_thumbnail_image', true ) ) {
+			$thumbnail_args['post_type'] = 'page';
+			new MultiPostThumbnails( $thumbnail_args );
+		}
 	}
 
 	/**


### PR DESCRIPTION
If a theme does not account specifically for backround and
thumbnail images, it should have the ability to disable them to
avoid unexpected output.