### PR TITLE
[PR] Add support for pre-2.0.0 WSU Spine release

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -303,9 +303,11 @@ add_action( 'wp_enqueue_scripts', 'spine_wp_enqueue_scripts', 20 );
 function spine_wp_enqueue_scripts() {
 
 	$spine_version = spine_get_option( 'spine_version' );
-	// This may be an unnecessary check, but we don't want to screw this up.
-	if ( 'develop' !== $spine_version && 0 === absint( $spine_version ) ) {
-		$spine_version = 1;
+
+	if ( 2 === absint( $spine_version ) ) {
+		$spine_version = 'develop'; // Use the develop branch temporarily for version 2.
+	} else {
+		$spine_version = 1; // Force the WSU Spine version to version 1 if any previously used (or invalid) option is set
 	}
 
 	// Much relies on the main stylesheet provided by the WSU Spine.

--- a/includes/theme-customizer.php
+++ b/includes/theme-customizer.php
@@ -578,7 +578,7 @@ class Spine_Theme_Customizer {
 			'type'     => 'select',
 			'choices'  => array(
 				'1'       => '1',
-				'develop' => 'develop',
+				'2'       => '2',
 			),
 		) );
 


### PR DESCRIPTION
This ensures that all sites previously configured for "1" or "develop" will use version 1 of the Spine and provides a new option to load version 2, which will be on the develop branch until February 26.