### PR TITLE
Build in initial Gutenberg support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1065,3 +1065,13 @@ add_action( 'init', 'remove_classic_editor_redirect' );
 function remove_classic_editor_redirect() {
 	remove_filter( 'redirect_post_location', 'gutenberg_redirect_to_classic_editor_when_saving_posts', 10 );
 }
+
+add_action( 'after_setup_theme', 'spine_gutenberg_support' );
+/**
+ * Add theme support for Gutenberg.
+ */
+function spine_gutenberg_support() {
+	add_theme_support( 'gutenberg', array(
+		'wide-images' => true,
+	) );
+}

--- a/functions.php
+++ b/functions.php
@@ -1021,3 +1021,47 @@ function spine_display_breadcrumbs( $position ) {
 
 	return false;
 }
+
+add_filter( 'gutenberg_can_edit_post_type', 'spine_gutenberg_page_templates', 10, 2 );
+/**
+ * Selectively add support for Gutenberg to posts and pages assigned to a specific page template.
+ *
+ * @param bool   $can_gutenberg Whether Gutenberg thinks it can provide an editor for this post.
+ * @param string $post_type     The post type being edited.
+ *
+ * @return bool Whether the theme thinks Gutenberg should provide the editor for this post.
+ */
+function spine_gutenberg_page_templates( $can_gutenberg, $post_type ) {
+	if ( 'post' === $post_type ) {
+		return true;
+	}
+
+	if ( 'page' === $post_type ) {
+		$post = get_post();
+
+		if ( ! $post ) {
+			return false;
+		}
+
+		$template = get_post_meta( $post->ID, '_wp_page_template', true );
+
+		if ( 'templates/gutenberg-beta.php' === $template ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	return $can_gutenberg;
+}
+
+add_action( 'init', 'remove_classic_editor_redirect' );
+/**
+ * Remove the "classic-editor" query arg appended to pages when a post is saved
+ * if the previous view did not support Gutenberg.
+ *
+ * This allows us to change Gutenberg support when the page template is changed for a page.
+ */
+function remove_classic_editor_redirect() {
+	remove_filter( 'redirect_post_location', 'gutenberg_redirect_to_classic_editor_when_saving_posts', 10 );
+}

--- a/templates/gutenberg-beta.php
+++ b/templates/gutenberg-beta.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Template Name: Gutenberg (Beta)
+ *
+ * Provides a template that can be used to enable the Gutenberg editor
+ * on pages without interrupting existing page builder templates.
+ */
+
+get_header();
+
+?>
+<main id="wsuwp-main" class="spine-gutenberg-beta-template">
+
+	<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+
+		<?php the_content(); ?>
+
+	<?php
+	endwhile;
+	endif;
+	?>
+</main>
+<?php
+get_footer();

--- a/templates/gutenberg-beta.php
+++ b/templates/gutenberg-beta.php
@@ -11,14 +11,29 @@ get_header();
 ?>
 <main id="wsuwp-main" class="spine-gutenberg-beta-template">
 
-	<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
+	<?php get_template_part( 'parts/featured-images' ); ?>
 
-		<?php the_content(); ?>
+	<header class="row single gutter pad-ends">
+		<h1 class="column one"><?php the_title(); ?></h1>
+	</header>
 
-	<?php
-	endwhile;
-	endif;
-	?>
+	<section class="row single gutter pad-bottom">
+
+		<div class="column one">
+
+			<?php
+			if ( have_posts() ) : while ( have_posts() ) : the_post();
+
+				the_content();
+
+			endwhile;
+			endif;
+
+			?>
+		</div>
+
+	</section>
+
 </main>
 <?php
 get_footer();


### PR DESCRIPTION
We should start getting used to Gutenberg as *the* editing tool at some level, even if our primary support for it will be in a new WSU Web Framework theme.

This gets things started and makes it easier to selectively use Gutenberg on pages depending on the template.

The next step will be to start playing with block styles.