### PR TITLE
Store instance of Spine Theme Setup class

### DIFF
--- a/includes/theme-setup.php
+++ b/includes/theme-setup.php
@@ -90,4 +90,4 @@ class Spine_Theme_Setup {
 		return '';
 	}
 }
-new Spine_Theme_Setup();
+$spine_theme_setup = new Spine_Theme_Setup();


### PR DESCRIPTION
Save the instance of the Spine Theme Setup class to a variable so that child themes and/or plugins can access it if needed.