### PR TITLE
Removed google plus from spine share options

### DIFF
--- a/parts/share-tools.php
+++ b/parts/share-tools.php
@@ -17,9 +17,6 @@ if ( ! empty( $spine_social_options['twitter'] ) ) {
 		<li class="by-twitter">
 			<a href="https://twitter.com/intent/tweet?text=<?php echo $post_share_title; ?>&amp;url=<?php echo $post_share_url; ?>&amp;via=<?php echo $twitter_handle; ?>" target="_blank"><span class="screen-reader-text channel-title">Share this page on Twitter</span></a>
 		</li>
-		<li class="by-googleplus">
-			<a href="https://plus.google.com/share?url=<?php echo $post_share_url; ?>" target="_blank"><span class="screen-reader-text channel-title">Share this page on Google Plus</span></a>
-		</li>
 		<li class="by-linkedin">
 			<a href="https://www.linkedin.com/shareArticle?mini=true&amp;url=<?php echo $post_share_url; ?>&amp;summary=<?php echo $post_share_title; ?>&amp;source=undefined" target="_blank"><span class="screen-reader-text channel-title">Share this page on Linked In</span></a>
 		</li>


### PR DESCRIPTION
Google plus was shut down back in april and the link currently goes nowhere