### PR TITLE
Feature/add wsu icons

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -409,6 +409,11 @@ function spine_wp_enqueue_scripts() {
 
 	wp_enqueue_style( 'spine-theme-print', get_template_directory_uri() . '/css/print.css', array(), spine_get_script_version(), 'print' );
 
+	// Check if WSU Icons should be enabled
+	if ( get_theme_mod( 'spine_enable_wsu_icons' ) ) {
+		wp_enqueue_style( 'spine-theme-wsu-icons', 'https://cdn-web-wsu.s3-us-west-2.amazonaws.com/designsystem/1.x/wsu-icons/dist/wsu-icons.bundle.css', array(), '1.x' );
+	}
+
 	// All theme styles have been output at this time. Plugins and other themes should print styles here, before blocking
 	// Javascript resources are output.
 	do_action( 'spine_enqueue_styles' );

--- a/includes/theme-customizer.php
+++ b/includes/theme-customizer.php
@@ -712,6 +712,19 @@ class Spine_Theme_Customizer {
 			),
 		) );
 
+		// Enable WSU Icons
+		$wp_customize->add_setting( 'spine_enable_wsu_icons', array(
+			'default'    => false,
+			'capability' => 'edit_theme_options',
+		) );
+
+		$wp_customize->add_control( 'spine_enable_wsu_icons', array(
+			'label'    => __( 'Enable WSU Icons', 'spine' ),
+			'section'  => 'section_spine_advanced_options',
+			'settings' => 'spine_enable_wsu_icons',
+			'type'     => 'checkbox',
+		) );
+
 		// If the Breadcrumb NavXT plugin is enabled, show breadcrumb options.
 		if ( function_exists( 'bcn_display' ) ) {
 			$wp_customize->add_setting( 'spine_options[show_breadcrumbs]', array(

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://github.com/washingtonstateuniversity/WSUWP-spine-parent-theme
 Author: WSU University Communications
 Author URI: https://web.wsu.edu/
 Description: Binding together the story of Washington State University.
-Version: 1.0.1
+Version: 1.1.0
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Tags: light, wsu


### PR DESCRIPTION
Creates a customizer setting to store whether or not the WSU Icons should be enqueued onto the frontend of the website. Adds the setting to the `Advanced Options` section in the customizer.

![image](https://user-images.githubusercontent.com/7292444/77591156-9dda9680-6eac-11ea-9257-be3b01b6bf01.png)
